### PR TITLE
feat: update SDS support and add passthrough mode

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -165,13 +165,36 @@ edgeca server -p opa/opa.rego
 ```
 
 ### Mode 3: Use TPP
-In this mode, you need to provide a TPP access token when starting up edgecad. 
 
-To use, specify the TPP URL, Zone and Access token. EdgeCA will then get an issuing certificate and policy information from the TPP server. 
+EdgeCA can integrate with a [Venafi](https://www.venafi.com) backend, using [Venafi VCert](https://www.github.com/Venafi/vcert). To use that, do the following:
+
+You should have a TPP URL,  Zone, username and password. First use VCert to generate a TPP token:
+
+```
+git clone https://github.com/Venafi/vcert.git
+cd vcert
+make build
+./bin/linux/vcert getcred -u YOUR_URL --username your_USERNAME --password YOUR_PASSWORD --client-id=edgeca
+
+```
+
+then use the generated token to start up EdgeCA, specifying the TPP URL, Zone and Access token. EdgeCA will then get an issuing certificate and policy information from the TPP server. 
 
 ```
 ./edgeca server --url "..." --zone "..." --token "..." 
 ```
+
+#### Pass-through mode
+
+Instead of having EdgeCA bootstrap itself with an issuing certificate and then issue its own certificates using that issuing certificate, you can have it 
+simply pass all certificate signing requests on to Venafi. To do that, use the `--passthrough` argument:
+
+```
+./edgeca server --url "..." --zone "..." --token "..."  --passthrough
+```
+
+
+
 
 ## Use the EdgeCA CLI
 

--- a/examples/sds/README.md
+++ b/examples/sds/README.md
@@ -69,8 +69,8 @@ openssl s_client --connect localhost:10000
 
 
  ```
- docker logs local-envoy
- docker logs remote-envoy
+ docker logs envoy-local
+ docker logs envoy-remote
  ```
 
 
@@ -115,4 +115,4 @@ curl --cacert ~/.edgeca/certs/CA.pem https://localhost:10000
 
 This curl command will use the CA cert from EdgeCA. It will connect to Envoy, which will in turn use TLS certificates provided to it by EdgeCA.
 
-The expected output is the webpage at https://edgeca.org, which is the one returned by the sample proxy configuration
+The expected output is an JSON file with information about your http request

--- a/examples/sds/example02/run-envoy-docker.sh
+++ b/examples/sds/example02/run-envoy-docker.sh
@@ -29,7 +29,6 @@ sudo docker run --rm -dit --name envoy-local --network envoy-edgeca-poc-net \
 
 
 sudo docker run --rm -dit --name http-echo --network envoy-edgeca-poc-net \
-      -p 8080:8080 -p 8443:8443 \
       mendhak/http-https-echo:18
 
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -97,7 +97,7 @@ func init() {
 	serverCmd.Flags().IntVarP(&tlsPort, "port", "", tlsPort, "Port number to use for this server")
 
 	serverCmd.Flags().BoolVarP(&useSDS, "sds", "", false, "Enable Envoy SDS support (development use only)")
-	//	serverCmd.Flags().BoolVarP(&usePassthrough, "passthrough", "", false, "Don't use an issuing certificate or issue certitificates locally. Pass all requests directly to TPP. ")
+	serverCmd.Flags().BoolVarP(&usePassthrough, "passthrough", "", false, "Don't use an issuing certificate or issue certitificates locally. Pass all requests directly to TPP. ")
 
 	serverCmd.Flags().IntVarP(&graphQLport, "graphql", "", 0, "Start a GraphQL server on the specified port")
 

--- a/internal/issuer/certificates.go
+++ b/internal/issuer/certificates.go
@@ -36,12 +36,6 @@ var subCACert *x509.Certificate
 var rsasubCAKey *rsa.PrivateKey
 var dersubCACert []byte
 
-func GenerateCertificateUsingCSR(csrByteString string, subCACert *x509.Certificate, casubCAKeyCert *rsa.PrivateKey) (certificate []byte, key []byte, expiry string, err error) {
-
-	subject := GetSubjectFromCSR(csrByteString)
-	return GenerateCertificateUsingX509Subject(subject, subCACert, casubCAKeyCert)
-}
-
 func GenerateCertificateUsingX509Subject(subject pkix.Name, subCACert *x509.Certificate, casubCAKeyCert *rsa.PrivateKey) (certificate []byte, key []byte, expiryString string, err error) {
 	log.Println("Got request for Certificate")
 


### PR DESCRIPTION
Instead of having EdgeCA bootstrap itself with an issuing certificate and then issue its own certificates 
using that issuing certificate, you can have it 
simply pass all certificate signing requests on to Venafi. To do that, use the `--passthrough` argument:

```
./edgeca server --url "..." --zone "..." --token "..."  --passthrough
```
This also works with SDS mode

```
edgeca server --url "" --zone "" --token ""  --passthrough --sds
```

SDS mode now also uses a simple cache



