### PR TITLE
feat: update logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
+GO111MODULE=on # Enable module mode
+GIT_VERSION=$(shell git describe --tags --abbrev=0 | sed 's/v//')
+GOFLAGS=-ldflags "-X github.com/edgesec-org/edgeca.Version=$(GIT_VERSION)"
+
 all: 
-	export GO111MODULE=on # Enable module mode
+	echo $(GOFLAGS)
 	go mod tidy
 	go get ./...
-	go build -o bin/edgeca ./cmd/edgeca 
+	go build $(GOFLAGS) -o bin/edgeca ./cmd/edgeca 
 
+docker:
+	docker build -t edgesec/edgeca .
+	docker push edgesec/edgeca
 
+snapcraft:
+	snapcraft --use-lxd

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.5.2
 	github.com/open-policy-agent/opa v0.27.1
+	github.com/prometheus/common v0.14.0
+	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.3
 	github.com/vektah/gqlparser/v2 v2.2.0
 	golang.org/x/net v0.0.0-20210610132358-84b48f89b13b // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,9 +29,11 @@ github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4Rq
 github.com/agnivade/levenshtein v1.0.3 h1:M5ZnqLOoZR8ygVq0FfkXsNOKzMCk0xRiow0R5+5VkQ0=
 github.com/agnivade/levenshtein v1.0.3/go.mod h1:4SFRZbbXWLF4MU1T9Qg0pGgH3Pjs+t6ie5efyrwRJXs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
@@ -222,6 +224,7 @@ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -322,6 +325,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
+github.com/prometheus/common v0.14.0 h1:RHRyE8UocrbjU+6UvRzwi6HjiDfxrrBU91TtbKzkGp4=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -349,6 +353,7 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -609,6 +614,7 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -17,8 +17,9 @@ package config
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"gopkg.in/yaml.v2"
 )
@@ -106,7 +107,7 @@ func SetCSRConfiguration(o string, ou string, c string, p string, l string) erro
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
-	log.Println("Updated configuration file " + configFile)
+	log.Debugln("Updated configuration file " + configFile)
 	return nil
 }
 

--- a/internal/issuer/pem.go
+++ b/internal/issuer/pem.go
@@ -22,8 +22,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"log"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func PemToRSAPrivateKey(pemKey []byte) (rsaKey *rsa.PrivateKey, err error) {
@@ -55,7 +56,7 @@ func PemToCert(pemCert []byte) (cert *x509.Certificate, err error) {
 
 	certificate, err := x509.ParseCertificate(derBytes)
 	if err != nil {
-		log.Println("ParseCertificate failed:", err)
+		log.Errorf("ParseCertificate failed %v:", err)
 	}
 	return certificate, err
 

--- a/internal/issuer/tls.go
+++ b/internal/issuer/tls.go
@@ -22,11 +22,12 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"io/ioutil"
-	"log"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func GenerateTLSServerCert(server string, parentCert *x509.Certificate, parentKey *rsa.PrivateKey) (*tls.Certificate, error) {
-	log.Println("Creating TLS server certificate for ", server)
+	log.Debugln("Creating TLS server certificate for ", server)
 	subject := pkix.Name{
 		Organization:       []string{"EdgeCA"},
 		OrganizationalUnit: []string{},
@@ -84,14 +85,14 @@ func GenerateTLSClientCert(server string, parentCert *x509.Certificate, parentKe
 		if err != nil {
 			log.Fatalf("Error writing output to %s: %v", certfilename, err)
 		}
-		log.Printf("Writing TLS Client certificate to %s", certfilename)
+		log.Debugf("Writing TLS Client certificate to %s", certfilename)
 	}
 	if keyfilename != "" {
 		err := ioutil.WriteFile(keyfilename, pemKey, 0644)
 		if err != nil {
 			log.Fatalf("Error writing output to %s: %v", keyfilename, err)
 		}
-		log.Printf("Writing TLS Client key to %s", keyfilename)
+		log.Debugf("Writing TLS Client key to %s", keyfilename)
 	}
 	return &cert, err
 }

--- a/internal/policies/opaimpl.go
+++ b/internal/policies/opaimpl.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"log"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/edgesec-org/edgeca/internal/server/tpp"
 	"github.com/open-policy-agent/opa/rego"
@@ -78,7 +79,7 @@ func createDefaultPolicyFile(commonName, organization, organizationalUnit, provi
 		"true\n" +
 		"}"
 
-	log.Println("Setting Policy to \n---\n", tppPolicy, "\n---\n")
+	log.Debugln("OPA: Setting Policy to \n---\n", tppPolicy, "\n---\n")
 	policy = tppPolicy
 
 }
@@ -100,11 +101,10 @@ func LoadPolicy(policyFilename string) {
 func CheckPolicy(csr string) error {
 
 	if policy == "" {
-		log.Println("No policy file was specified")
 		return nil
 	}
 
-	log.Println("Applying policy from ", filename)
+	log.Debugln("OPA: Applying policy from ", filename)
 
 	// create the JSON object with the CSR
 	ctx := context.TODO()

--- a/internal/server/graphql.go
+++ b/internal/server/graphql.go
@@ -16,9 +16,10 @@
 package server
 
 import (
-	"log"
 	"net/http"
 	"strconv"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -34,6 +35,6 @@ func StartGraphqlServer(port int) {
 	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
 	http.Handle("/query", srv)
 
-	log.Printf("connect to http://localhost:%s/ for GraphQL playground", sPort)
+	log.Debugf("connect to http://localhost:%s/ for GraphQL playground", sPort)
 	log.Fatal(http.ListenAndServe(":"+sPort, nil))
 }

--- a/internal/server/sds/sdsimpl.go
+++ b/internal/server/sds/sdsimpl.go
@@ -18,8 +18,9 @@ package sds
 import (
 	"context"
 	"crypto/x509/pkix"
-	"log"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -92,7 +93,7 @@ func (s *server) StreamSecrets(stream secretservice.SecretDiscoveryService_Strea
 			hostname := req.GetResourceNames()[0]
 			resp, _ := getResponse(hostname)
 			s.streamCount++
-			//		log.Printf("SDS: Processing request for certificates for %v", req.GetResourceNames())
+			//		log.Debugf("SDS: Processing request for certificates for %v", req.GetResourceNames())
 			stream.Send(resp)
 
 		}
@@ -104,13 +105,13 @@ func (s *server) StreamSecrets(stream secretservice.SecretDiscoveryService_Strea
 
 func (s *server) FetchSecrets(ctx context.Context, req *discovery.DiscoveryRequest) (*discovery.DiscoveryResponse, error) {
 
-	log.Println("SDS: FetchSecrets")
+	log.Debugln("SDS: FetchSecrets")
 
 	return nil, nil
 }
 
 func (s *server) DeltaSecrets(stream secretservice.SecretDiscoveryService_DeltaSecretsServer) error {
-	log.Println("SDS: DeltaSecrets")
+	log.Debugln("SDS: DeltaSecrets")
 
 	return nil
 }
@@ -143,12 +144,12 @@ func generateSDSCertificate(host string) (pemCert, pemKey string, err error) {
 	var pemCertificateString, pemPrivateKeyString string
 
 	if state.UsingPassthrough() {
-		log.Println("SDS: Using TPP to sign certificate for " + host)
+		log.Debugln("SDS: Using TPP to sign certificate for " + host)
 
 		_, pemCertificateString, pemPrivateKeyString, err = state.GenerateCertificateUsingTPP(pkix.Name{CommonName: host})
 
 	} else {
-		log.Println("SDS: Using EdgeCA issuing certificate to sign certificate for " + host)
+		log.Debugln("SDS: Using EdgeCA issuing certificate to sign certificate for " + host)
 
 		var pemCertificate, pemPrivateKey []byte
 		pemCertificate, pemPrivateKey, _, err = certs.GeneratePemCertificate(pkix.Name{CommonName: host}, state.GetSubCACert(), state.GetSubCAKey())
@@ -186,11 +187,11 @@ func makeSecret(host string) *tls.Secret {
 
 	s, found := secrets[host]
 	if found {
-		log.Println("SDS: returning cached certificate for " + host)
+		log.Debugln("SDS: returning cached certificate for " + host)
 		pemCert = s.certificate
 		pemKey = s.key
 	} else {
-		log.Println("SDS: Caching certificate for " + host)
+		log.Debugln("SDS: Caching certificate for " + host)
 		pemCert, pemKey, _ = generateSDSCertificate(host)
 		secrets[host] = secret{certificate: pemCert, key: pemKey}
 	}

--- a/version.go
+++ b/version.go
@@ -15,4 +15,4 @@
 
 package edgeca
 
-var Version string = "0.4.6"
+var Version string = "to be replaced in makefile"


### PR DESCRIPTION
- use a 3rd party logging library instead of the golang logger.  We now have both INFO and DEBUG log messages
- using the `-d` or `--debug` argument when running edgeca (i.e. `./bin/edgeca server -d` ) will now enable `debug` logging
- Updated the logging messages and in particular when a certificate is signed we now get messages like

```
DEBU[0001] gRPC request: certificate for localhost from issuer: Local Self Signed CA (EdgeCASubCA/EdgeCARootCA)
```

and if using a user-provided Root CA cert, or Venafi TPP issuing cert or TPP passthrough, we should get the appropriate log messages.

Signed-off-by: Siggi Skulason <siggi@edgesec.org>