### PR TITLE
feat: add HSM support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/99designs/gqlgen v0.13.0
+	github.com/ThalesIgnite/crypto11 v1.2.4
 	github.com/Venafi/vcert/v4 v4.13.1
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d
 	github.com/gogo/protobuf v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/ThalesIgnite/crypto11 v1.2.4 h1:3MebRK/U0mA2SmSthXAIZAdUA9w8+ZuKem2O6HuR1f8=
+github.com/ThalesIgnite/crypto11 v1.2.4/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/Venafi/vcert/v4 v4.13.1 h1:T+ZAygGBhncKGUFCtBth2rXrokJkGv8cOeEOgx9XLzc=
 github.com/Venafi/vcert/v4 v4.13.1/go.mod h1:Z3sJFoAurFNXPpoSUSHq46aIeHLiGQEMDhprfxlpofQ=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
@@ -248,6 +250,8 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f h1:eVB9ELsoq5ouItQBr5Tj334bhPJG/MX+m7rTchmzVUQ=
+github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -385,6 +389,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
+github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/internal/cmd/hsm.go
+++ b/internal/cmd/hsm.go
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package cmd
+
+import (
+	"github.com/edgesec-org/edgeca/internal/config"
+	"github.com/edgesec-org/edgeca/internal/server/hsm"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+
+	var hsmCmd = &cobra.Command{
+		Use:   "hsm",
+		Short: "HSM commands",
+		Args:  cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+
+		}}
+
+	var statusCmd = &cobra.Command{
+		Use:   "status",
+		Short: "Show HSM status",
+		Long: `
+			`,
+		Run: func(cmd *cobra.Command, args []string) {
+			config.InitCLIConfiguration(configDir)
+			hsm.ListHSMAllKeys()
+		}}
+
+	configDir = config.GetDefaultConfdir()
+	statusCmd.Flags().StringVarP(&configDir, "confdir", "", configDir, "Configuration Directory")
+
+	rootCmd.AddCommand(hsmCmd)
+	hsmCmd.AddCommand(statusCmd)
+
+}

--- a/internal/issuer/certificates_test.go
+++ b/internal/issuer/certificates_test.go
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package issuer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edgesec-org/edgeca/internal/config"
+)
+
+func TestX509HSM(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	config.InitCLIConfiguration(home + "/.edgeca")
+
+	err := GenerateSelfSignedRootCACertAndKey()
+	if err != nil {
+		t.Fatalf("GetEdgeRootCASigner %v", err)
+	}
+
+}

--- a/internal/issuer/tls.go
+++ b/internal/issuer/tls.go
@@ -16,7 +16,6 @@
 package issuer
 
 import (
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -26,7 +25,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func GenerateTLSServerCert(server string, parentCert *x509.Certificate, parentKey *rsa.PrivateKey) (*tls.Certificate, error) {
+func GenerateTLSServerCert(server string) (*tls.Certificate, error) {
 	log.Infoln("Creating TLS server certificate for ", server)
 	subject := pkix.Name{
 		Organization:       []string{"EdgeCA"},
@@ -37,7 +36,7 @@ func GenerateTLSServerCert(server string, parentCert *x509.Certificate, parentKe
 		Country:            []string{},
 	}
 
-	pemCert, pemKey, _, err := GeneratePemCertificate(subject, parentCert, parentKey)
+	pemCert, pemKey, _, err := GeneratePemCertificate(subject, false)
 	if err != nil {
 		return nil, err
 	}
@@ -56,13 +55,14 @@ func LoadCAServerCert(filename string) (*x509.CertPool, error) {
 
 	certPool := x509.NewCertPool()
 	if !certPool.AppendCertsFromPEM(pemCert) {
-		return nil, errors.New("Could not append CA Certificate")
+		return nil, errors.New("could not append CA Certificate")
 	}
 
 	return certPool, nil
 }
 
-func GenerateTLSClientCert(server string, parentCert *x509.Certificate, parentKey *rsa.PrivateKey, certfilename string, keyfilename string) (*tls.Certificate, error) {
+func GenerateTLSClientCert(server string, certfilename string, keyfilename string) (*tls.Certificate, error) {
+	log.Infoln("Creating TLS client certificate for ", server)
 
 	subject := pkix.Name{
 		Organization:       []string{"EdgeCA"},
@@ -73,7 +73,7 @@ func GenerateTLSClientCert(server string, parentCert *x509.Certificate, parentKe
 		Country:            []string{},
 	}
 
-	pemCert, pemKey, _, err := GeneratePemCertificate(subject, parentCert, parentKey)
+	pemCert, pemKey, _, err := GeneratePemCertificate(subject, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/issuer/x509.go
+++ b/internal/issuer/x509.go
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package issuer
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/edgesec-org/edgeca/internal/server/hsm"
+	log "github.com/sirupsen/logrus"
+)
+
+func signCertificateAndDEREncode(certificate, parent *x509.Certificate, parentPrivateKey *rsa.PrivateKey, privateKey *rsa.PrivateKey) (der []byte, err error) {
+	der, err = x509.CreateCertificate(rand.Reader, certificate, parent, &privateKey.PublicKey, parentPrivateKey)
+	return
+}
+
+func generateX509ertificate(subject pkix.Name, keyUsage x509.KeyUsage, isCA bool) (*x509.Certificate, string) {
+
+	notBefore := time.Now()
+	notAfter := notBefore.AddDate(1, 0, 0)
+
+	var cert x509.Certificate
+
+	cert = x509.Certificate{
+		SerialNumber:          &serialNumber,
+		Subject:               subject,
+		DNSNames:              []string{subject.CommonName},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		KeyUsage:              keyUsage,
+		IsCA:                  isCA,
+	}
+
+	//	if !isCA {
+	//		cert.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	//	}
+
+	serialNumber.Add(&serialNumber, big.NewInt(1))
+	notAfterStr := fmt.Sprintf(cert.NotAfter.Format(time.RFC3339))
+
+	return &cert, notAfterStr
+
+}
+
+func GenerateHSMSignedCertificate(unsignedCertificate *x509.Certificate, signerName string, parent *x509.Certificate, parentSignerName string) (*x509.Certificate, []byte, error) {
+
+	signer, err := hsm.GetHSMSigner(signerName)
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificate failed:", err)
+		return nil, nil, err
+	}
+
+	var parentSigner crypto.Signer
+
+	if parent == nil {
+		parent = unsignedCertificate
+		parentSigner = signer
+	} else {
+		parentSigner, err = hsm.GetHSMSigner(parentSignerName)
+		if err != nil {
+			log.Debugln("GenerateHSMSignedCertificate failed:", err)
+			return nil, nil, err
+		}
+	}
+	derRsaRootCert, err := x509.CreateCertificate(rand.Reader, unsignedCertificate, parent, signer.Public(), parentSigner)
+
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificate failed:", err)
+		return nil, nil, err
+	}
+
+	certificate, err := x509.ParseCertificate(derRsaRootCert)
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificate failed:", err)
+		return nil, nil, err
+	}
+
+	pemCACert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derRsaRootCert})
+	return certificate, pemCACert, nil
+
+}
+
+func GenerateHSMSignedCertificateWithPrivateKey(unsignedCertificate *x509.Certificate, parent *x509.Certificate, parentSignerName string) (*x509.Certificate, []byte, *rsa.PrivateKey, error) {
+
+	privateKey, _ := GenerateRSAKey()
+
+	parentSigner, err := hsm.GetHSMSigner(parentSignerName)
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificateWithPrivateKey GetHSMSigner failed:", err)
+		return nil, nil, nil, err
+	}
+
+	derRsaRootCert, err := x509.CreateCertificate(rand.Reader, unsignedCertificate, parent, &privateKey.PublicKey, parentSigner)
+
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificateWithPrivateKey CreateCertificate failed:", err)
+		return nil, nil, nil, err
+	}
+
+	certificate, err := x509.ParseCertificate(derRsaRootCert)
+	if err != nil {
+		log.Debugln("GenerateHSMSignedCertificateWithPrivateKey ParseCertificate failed:", err)
+		return nil, nil, nil, err
+	}
+
+	pemCACert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derRsaRootCert})
+	return certificate, pemCACert, privateKey, nil
+
+}
+
+func GenerateSignedCertificate(unsignedCertificate *x509.Certificate, parent *x509.Certificate, parentPrivateKey *rsa.PrivateKey) (*x509.Certificate, []byte, *rsa.PrivateKey, error) {
+
+	privateKey, err := GenerateRSAKey()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if parent == nil {
+		parent = unsignedCertificate
+		parentPrivateKey = privateKey
+	}
+
+	derRsaRootCert, err := signCertificateAndDEREncode(unsignedCertificate, parent, privateKey, parentPrivateKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	certificate, err := x509.ParseCertificate(derRsaRootCert)
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pemCACert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derRsaRootCert})
+
+	return certificate, pemCACert, privateKey, nil
+}

--- a/internal/issuer/x509_test.go
+++ b/internal/issuer/x509_test.go
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package issuer
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"os"
+	"testing"
+
+	"github.com/edgesec-org/edgeca/internal/config"
+	"github.com/edgesec-org/edgeca/internal/server/hsm"
+)
+
+func TestCertificates(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	config.InitCLIConfiguration(home + "/.edgeca")
+
+	signer, err := hsm.GetHSMSigner("EDGECA-ROOT-CA")
+	if err != nil {
+		t.Fatalf("GetEdgeRootCASigner %v", err)
+	}
+
+	if signer == nil {
+		t.Fatalf("GetEdgeRootCASigner signer = nil")
+	}
+
+	root := pkix.Name{
+		CommonName: "EdgeCARootCA",
+	}
+
+	unsignedCertificate, _ := generateX509ertificate(root, x509.KeyUsageCertSign|x509.KeyUsageCRLSign, true)
+
+	parentCertificate, _, err := GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
+	if err != nil {
+		t.Fatalf("GetEdgeRootCASigner %v", err)
+	}
+
+	_, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-SUB-CA", parentCertificate, "EDGECA-ROOT-CA")
+	if err != nil {
+		t.Fatalf("GetEdgeRootCASigner %v", err)
+	}
+
+	config.SetHSMConfiguration("", "", "")
+	hsm.ResetConfiguration()
+
+	_, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
+	if err == nil {
+		t.Fatalf("GenerateHSMSignedCertificate should fail when HSM isn't set up")
+	}
+}

--- a/internal/server/graphqlimpl/graph/schema.resolvers.go
+++ b/internal/server/graphqlimpl/graph/schema.resolvers.go
@@ -54,7 +54,7 @@ func (r *mutationResolver) CreateCertificate(ctx context.Context, input model.Ne
 
 		var bCertificate, bPrivateKey []byte
 
-		bCertificate, bPrivateKey, expiryStr, err = issuer.GenerateCertificateUsingX509Subject(subject, state.GetSubCACert(), state.GetSubCAKey())
+		bCertificate, bPrivateKey, expiryStr, err = issuer.GenerateCertificateUsingX509Subject(subject)
 		pemCertificate = string(bCertificate)
 		pemPrivateKey = string(bPrivateKey)
 	}

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -78,7 +78,7 @@ func (s *server) GenerateCertificate(ctx context.Context, request *grpcimpl.Cert
 
 		log.Infoln("gRPC request: certificate for " + subject.CommonName + " from issuer: " + state.GetStateDescription())
 
-		bCertificate, bPrivateKey, _, err = issuer.GenerateCertificateUsingX509Subject(subject, state.GetSubCACert(), state.GetSubCAKey())
+		bCertificate, bPrivateKey, _, err = issuer.GenerateCertificateUsingX509Subject(subject)
 		pemCertificate = string(bCertificate)
 		pemPrivateKey = string(bPrivateKey)
 
@@ -91,7 +91,7 @@ func (s *server) GenerateCertificate(ctx context.Context, request *grpcimpl.Cert
 func StartGrpcServer(port int, useSDS bool) {
 
 	certPool := x509.NewCertPool()
-	cacert := state.GetRootCACert()
+	cacert := state.GetRootCAPEMCert()
 	subCA := state.GetSubCAPEMCert()
 	certs := make([]byte, len(cacert)+len(subCA))
 	copy(certs, cacert)

--- a/internal/server/hsm/hsmimpl.go
+++ b/internal/server/hsm/hsmimpl.go
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package hsm
+
+import (
+	"crypto"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ThalesIgnite/crypto11"
+	"github.com/edgesec-org/edgeca/internal/config"
+	"github.com/prometheus/common/log"
+)
+
+var ctx *crypto11.Context
+
+var label = "edgeca"
+
+func setupHSM() (err error) {
+
+	path, token, pin := config.GetHSMConfiguration()
+
+	if path == "" || token == "" || pin == "" {
+		return errors.New("HSM is not configured in EdgeCA config file")
+	}
+
+	pc := &crypto11.Config{
+		Path:       path,
+		TokenLabel: token,
+		Pin:        pin,
+	}
+
+	// this needs to be set for the softhsm library to find the config file
+	hsmConfigFile := config.GetSoftHSMConfigFile()
+	os.Setenv("SOFTHSM2_CONF", hsmConfigFile)
+	log.Infof("SOFTHSM2_CONF file set to %s", hsmConfigFile)
+	ctx, err = crypto11.Configure(pc)
+
+	return
+}
+
+func ResetConfiguration() {
+	ctx = nil
+}
+
+func GetHSMSigner(signerName string) (signer crypto.Signer, err error) {
+
+	if ctx == nil {
+		err = setupHSM()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ID := []byte(signerName)
+
+	signer, err = ctx.FindKeyPair(ID, []byte(label))
+
+	if signer == nil {
+		_, err = ctx.GenerateRSAKeyPairWithLabel(ID, []byte(label), 2048)
+		if err != nil {
+			return nil, err
+		}
+
+		signer, err = ctx.FindKeyPair(ID, nil)
+	}
+
+	return signer, err
+
+}
+
+func ListHSMAllKeys() (err error) {
+
+	if ctx == nil {
+		err = setupHSM()
+		if err != nil {
+			fmt.Printf("HSM is disabled. Run setup_hsm.sh script to set up\n")
+			return nil
+		}
+	}
+
+	keys, _ := ctx.FindAllKeyPairs()
+	fmt.Printf("HSM status: %d keys found:\n\n", len(keys))
+	for i, key := range keys {
+		a, _ := ctx.GetAttribute(key, crypto11.CkaId)
+		fmt.Printf("Key %d: %v\n", i, string(a.Value))
+	}
+	return nil
+}

--- a/internal/server/hsm/hsmimpl_test.go
+++ b/internal/server/hsm/hsmimpl_test.go
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package hsm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/edgesec-org/edgeca/internal/config"
+)
+
+func TestRSA(t *testing.T) {
+
+	home, _ := os.UserHomeDir()
+
+	config.InitCLIConfiguration(home + "/.edgeca")
+
+	signer, err := GetHSMSigner("EDGECA-ROOT-CA")
+	if err != nil {
+		t.Fatalf("GetHSMSigner %v", err)
+	}
+
+	if signer == nil {
+		t.Fatalf("GetHSMSigner signer = nil")
+	}
+
+	ListHSMAllKeys()
+}

--- a/internal/server/sds/sdsimpl.go
+++ b/internal/server/sds/sdsimpl.go
@@ -152,7 +152,7 @@ func generateSDSCertificate(host string) (pemCert, pemKey string, err error) {
 		log.Debugln("SDS: Using EdgeCA issuing certificate to sign certificate for " + host)
 
 		var pemCertificate, pemPrivateKey []byte
-		pemCertificate, pemPrivateKey, _, err = certs.GeneratePemCertificate(pkix.Name{CommonName: host}, state.GetSubCACert(), state.GetSubCAKey())
+		pemCertificate, pemPrivateKey, _, err = certs.GeneratePemCertificate(pkix.Name{CommonName: host}, false)
 		pemCertificateString = string(pemCertificate)
 		pemPrivateKeyString = string(pemPrivateKey)
 	}

--- a/scripts/setup_hsm.sh
+++ b/scripts/setup_hsm.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+EDGECA_DIR="$HOME/.edgeca"
+SOFTHSM_DIR="$EDGECA_DIR/hsm"
+
+rm -rf $EDGECA_DIR/hsm
+mkdir -p $SOFTHSM_DIR
+mkdir -p $SOFTHSM_DIR/tokens
+
+
+echo "directories.tokendir = ${SOFTHSM_DIR}/tokens
+objectstore.backend = file
+log.level = INFO
+" > $SOFTHSM_DIR/softhsm2.conf
+ 
+
+SOFTHSM2_CONF=$SOFTHSM_DIR/softhsm2.conf softhsm2-util --init-token --slot 0 --label edgeca  --pin 1234 --so-pin 1234


### PR DESCRIPTION

add HSM support

fix #28

To test this, do

1. Install SoftHSM

```
git clone https://github.com/opendnssec/SoftHSMv2.git
cd SoftHSMv2
sh autogen.sh
./configure
make
sudo make install
export SOFTHSM2_CONF=/home/user/config.file

```

2.  Get the newest EdgeCA source and run the install script to set up the configuration files in ~/.edgeca

```
$ ./scripts/setur_hsm.sh
The token has been initialized and is reassigned to slot 152347386
```

You can now get the HSM status from EdgeCA

```
$ edgeca hsm status
INFO[0000] Loading configuration file : /home/sidar/.edgeca/config.yaml 
INFO[0000] SOFTHSM2_CONF file set to /home/sidar/.edgeca/hsm/softhsm2.conf  source="hsmimpl.go:50"
HSM status: 0 keys found:

```

If you have not run the hsm setup script, then you would instead see 

```
INFO[0000] Creating config directory at : /home/sidar/.edgeca 
INFO[0000] Creating default configuration file at : /home/sidar/.edgeca/config.yaml 
INFO[0000] SOFTHSM2_CONF file set to /home/sidar/.edgeca/hsm/softhsm2.conf  source="hsmimpl.go:50"
HSM is disabled. Run setup_hsm.sh script to set up
```

Now start up the server

```
$ edgeca server
EdgeCA server 0.6.5 starting up
INFO[0000] Loading configuration file : /home/sidar/.edgeca/config.yaml 
INFO[0000] Server mode: self-signed                     
INFO[0000] SOFTHSM2_CONF file set to /home/sidar/.edgeca/hsm/softhsm2.conf  source="hsmimpl.go:50"
INFO[0000] Creating TLS server certificate for  sidar-XPS-8930 
INFO[0000] Creating TLS client certificate for  sidar-XPS-8930 
INFO[0000] Writing TLS Client certificate to /home/sidar/.edgeca/certs/edgeca-client-cert.pem 
INFO[0000] Writing TLS Client key to /home/sidar/.edgeca/certs/edgeca-client-key.pem 
INFO[0000] Writing Root CA Certificate to  /home/sidar/.edgeca/certs/CA.pem 
INFO[0000] GraphQL server disabled                      
INFO[0000] SDS server disabled                          
INFO[0000] gRPC server started on port 50025            
INFO[0000] Starting gRPC CA server on port 50025  
```

Running `edgeca status hsm` will now show that the ROOT and SUB CA keys are in the HSM
```
$ edgeca hsm status

HSM status: 2 keys found:

Key 0: EDGECA-SUB-CA
Key 1: EDGECA-ROOT-CA
```

Keep EdgeCA server running and generate a certificate

```
./bin/edgeca gencert --csr csrfile
```
The private key is not accessible - it's in the HSM, so the key output will be the string

```
STORED IN HSM
```

```
$ edgeca hsm status
INFO[0000] Loading configuration file : /home/sidar/.edgeca/config.yaml 
INFO[0000] SOFTHSM2_CONF file set to /home/sidar/.edgeca/hsm/softhsm2.conf  source="hsmimpl.go:50"
HSM status: 3 keys found:

Key 0: EDGECA-SUB-CA
Key 1: EDGECA-ROOT-CA
Key 2: localhost
```

