### PR TITLE
feat: add JWT support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/ThalesIgnite/crypto11 v1.2.4
 	github.com/Venafi/vcert/v4 v4.13.1
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d
+	github.com/go-chi/chi v3.3.2+incompatible
 	github.com/gogo/protobuf v1.2.1
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/open-policy-agent/opa v0.27.1
 	github.com/prometheus/common v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,7 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v3.3.2+incompatible h1:uQNcQN3NsV1j4ANsPh42P4ew4t6rnRbJb8frvpp31qQ=
 github.com/go-chi/chi v3.3.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -126,6 +127,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/internal/auth/jwt/jwtimpl.go
+++ b/internal/auth/jwt/jwtimpl.go
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright 2021 EdgeSec Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *******************************************************************************/
+
+package jwt
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"time"
+
+	golangjwt "github.com/golang-jwt/jwt"
+	"github.com/prometheus/common/log"
+)
+
+var jwtKey *rsa.PrivateKey
+
+var jwtContext = &contextKey{"userid"}
+
+type contextKey struct {
+	name string
+}
+
+func GenerateToken() (string, error) {
+	var err error
+
+	if jwtKey == nil {
+		keyLength := 1024
+		jwtKey, err = rsa.GenerateKey(rand.Reader, keyLength)
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	token := golangjwt.NewWithClaims(golangjwt.SigningMethodRS256, golangjwt.MapClaims{
+		"iss": "EdgeCA",
+		"sub": "user",
+		"exp": time.Now().AddDate(0, 1, 0).UTC().Unix(),
+	})
+
+	// Sign and get the complete encoded token as a string using the secret
+	tokenString, err := token.SignedString(jwtKey)
+
+	return tokenString, err
+}
+
+func ParseToken(tokenString string) (string, error) {
+
+	token, err := golangjwt.Parse(tokenString, func(token *golangjwt.Token) (interface{}, error) {
+		return &jwtKey.PublicKey, nil
+	})
+
+	if err != nil {
+
+		return "", err
+	}
+
+	claims, ok := token.Claims.(golangjwt.MapClaims)
+
+	if claims == nil {
+		log.Errorf("claims == nil")
+	}
+
+	if !ok {
+		log.Errorf("!ok")
+	}
+
+	if ok && token.Valid {
+		username := claims["sub"].(string)
+		return username, nil
+	} else {
+		return "", err
+	}
+}
+
+func Middleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header := r.Header.Get("Authorization")
+
+			// Allow unauthenticated users in
+			if header == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			tokenStr := header
+			username, err := ParseToken(tokenStr)
+			var userid string
+			if err != nil {
+				log.Infof("GraphQL JWT token error: %v", err)
+			} else {
+				userid, err = getUserID(username)
+				if err != nil {
+					log.Infof("GraphQL JWT token error: invalid user")
+				}
+			}
+			c := context.WithValue(r.Context(), jwtContext, &userid)
+			r = r.WithContext(c)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func getUserID(username string) (id string, err error) {
+	if username == "user" {
+		return "1", nil
+	} else {
+		return "", fmt.Errorf("user %s unknown", username)
+	}
+}
+
+func UserIDFromContext(ctx context.Context) string {
+	userID, _ := ctx.Value(jwtContext).(*string)
+	if userID == nil {
+		return ""
+	} else {
+		return *userID
+
+	}
+}

--- a/internal/auth/mtls/tls.go
+++ b/internal/auth/mtls/tls.go
@@ -13,7 +13,7 @@
  *
  *******************************************************************************/
 
-package issuer
+package mtls
 
 import (
 	"crypto/tls"
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"io/ioutil"
 
+	"github.com/edgesec-org/edgeca/internal/issuer"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -36,7 +37,7 @@ func GenerateTLSServerCert(server string) (*tls.Certificate, error) {
 		Country:            []string{},
 	}
 
-	pemCert, pemKey, _, err := GeneratePemCertificate(subject, false)
+	pemCert, pemKey, _, err := issuer.GeneratePemCertificate(subject, false)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +74,7 @@ func GenerateTLSClientCert(server string, certfilename string, keyfilename strin
 		Country:            []string{},
 	}
 
-	pemCert, pemKey, _, err := GeneratePemCertificate(subject, false)
+	pemCert, pemKey, _, err := issuer.GeneratePemCertificate(subject, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/gencert.go
+++ b/internal/cmd/gencert.go
@@ -26,8 +26,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/edgesec-org/edgeca"
+	"github.com/edgesec-org/edgeca/internal/auth/mtls"
 	"github.com/edgesec-org/edgeca/internal/config"
-	certs "github.com/edgesec-org/edgeca/internal/issuer"
 	internalgrpc "github.com/edgesec-org/edgeca/internal/server/grpcimpl"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -133,7 +133,7 @@ func grpcConnect(tlsCertDir, host string, port int) (*grpc.ClientConn, internalg
 
 	log.Debugln("Loading TLS certificates from " + tlsCertDir)
 
-	certPool, err := certs.LoadCAServerCert(tlsCertDir + "/CA.pem")
+	certPool, err := mtls.LoadCAServerCert(tlsCertDir + "/CA.pem")
 	if err != nil {
 		log.Fatalf("Could not load CA certificate for TLS connection: %s", err)
 	}

--- a/internal/config/configfile.go
+++ b/internal/config/configfile.go
@@ -133,7 +133,7 @@ func InitCLIConfiguration(configDir string) {
 		WriteConfigFile()
 
 	} else {
-		log.Infof("Loading configuration file : %s", configFile)
+		log.Debugf("Loading configuration file : %s", configFile)
 
 		yamlFile, err := ioutil.ReadFile(configFile)
 		if err != nil {

--- a/internal/config/configfile_test.go
+++ b/internal/config/configfile_test.go
@@ -24,11 +24,12 @@ func TestConfig(t *testing.T) {
 
 	// delete config file
 	homedir, _ := os.UserHomeDir()
-	filename := homedir + "/.edgeca/config.yaml"
+	homedir += "/.edgeca/"
+	filename := homedir + "config.yaml"
 
 	os.Remove(filename)
 	// initialize - read config - set defaults
-	InitCLIConfiguration()
+	InitCLIConfiguration(homedir)
 
 	// check defaults
 	configGraphQLport := GetGraphQLPort()
@@ -67,7 +68,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	configTLSHostname := GetServerTLSHost()
-	defaultTLSCHostname := getDefaultTLSHost()
+	defaultTLSCHostname, _ := os.Hostname()
 
 	if defaultTLSCHostname == "" {
 		t.Errorf("defaultTLSCHostname is empty")
@@ -145,7 +146,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// read config file
-	InitCLIConfiguration()
+	InitCLIConfiguration(homedir)
 	// and remove it
 	os.Remove(filename)
 

--- a/internal/issuer/x509_test.go
+++ b/internal/issuer/x509_test.go
@@ -55,7 +55,7 @@ func TestCertificates(t *testing.T) {
 		t.Fatalf("GetEdgeRootCASigner %v", err)
 	}
 
-	config.SetHSMConfiguration("", "", "")
+	config.SetHSMConfiguration("", "", "", false)
 	hsm.ResetConfiguration()
 
 	_, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")

--- a/internal/server/graphqlimpl/graph/schema.resolvers.go
+++ b/internal/server/graphqlimpl/graph/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 
+	"github.com/edgesec-org/edgeca/internal/auth/jwt"
 	"github.com/edgesec-org/edgeca/internal/issuer"
 	"github.com/edgesec-org/edgeca/internal/server/graphqlimpl/graph/generated"
 	"github.com/edgesec-org/edgeca/internal/server/graphqlimpl/graph/model"
@@ -21,6 +22,11 @@ func (r *mutationResolver) CreateCertificate(ctx context.Context, input model.Ne
 	var pemCertificate, pemPrivateKey, expiryStr string
 	var subject pkix.Name
 
+	userID := jwt.UserIDFromContext(ctx)
+	if userID == "" {
+		var result model.Certificate
+		return &result, fmt.Errorf("access denied - JWT token missing/invalid")
+	}
 	subject.CommonName = input.CommonName
 
 	if input.Organization != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/edgesec-org/edgeca/internal/auth/mtls"
 	"github.com/edgesec-org/edgeca/internal/issuer"
 	certs "github.com/edgesec-org/edgeca/internal/issuer"
 	"github.com/edgesec-org/edgeca/internal/policies"
@@ -135,21 +136,16 @@ func InitStateUsingCerts(caCert, caKey, tlsCertDir string) error {
 
 }
 
-func getDefaultTLSHost() string {
-	hostName, _ := os.Hostname()
-	return hostName
-}
-
 func setupTLSConnection(certDir string) {
 	var err error
-	hostName := getDefaultTLSHost()
+	hostName, _ := os.Hostname()
 
-	serverState.tlsCertificate, err = certs.GenerateTLSServerCert(hostName)
+	serverState.tlsCertificate, err = mtls.GenerateTLSServerCert(hostName)
 	if err != nil {
 		log.Fatalln("Could not initialize TLS: ", err)
 	}
 
-	_, err = certs.GenerateTLSClientCert(hostName, certDir+"/edgeca-client-cert.pem", certDir+"/edgeca-client-key.pem")
+	_, err = mtls.GenerateTLSClientCert(hostName, certDir+"/edgeca-client-cert.pem", certDir+"/edgeca-client-key.pem")
 
 	if err != nil {
 		log.Fatalln("Could not create TLS client cert: ", err)


### PR DESCRIPTION
GraphQL now uses JWT tokens for authentication. Do the following:

```
edgeca config graphql --port 9000
edgeca server
```

Note the JWT token output when the server starts. Then go to

[GraphQL playground](http://localhost:9000) and try the following query:

```
mutation {
  createCertificate(input: {commonName: "localhost",organization:"ACME inc"}){
    certificate,
    key,
    expiry
  }
}
```

This will return in an error as you are not authenticated. Authenticate by clicking on "HTTP HEADERS" in the bottom pane,
and enter the JWT token. For example:

```
{"Authorization": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MzM0NTM5OTIsImlzcyI6IkVkZ2VDQSIsInN1YiI6InVzZXIifQ.js-Iq8gJFD9BwNGWAwnor4sz7KHYV5z2Yb4FdfwT9FLRpNpDALqELruB6V1wiWYqi2PbfwdT0ksitZuz9NTGQcnlYPdEt8TSizOdzl7ABoweagkF7OEwEOgTN1S2waD9vs4AwOGtqVPC8gXVgSV3UtG68F6GA8FsJtKdXeJzUIU"}
```

Run the query again and you should now get the expected result.