### PR TITLE
feat(hsm): update HSM support to use UUID for CKA_ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
+	github.com/google/uuid v1.1.2
 	github.com/open-policy-agent/opa v0.27.1
 	github.com/prometheus/common v0.14.0
 	github.com/sirupsen/logrus v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -34,6 +34,7 @@ var configDebugLogging bool
 var configGraphQLEnabled bool
 var err error
 var confconfigDir string
+var enableHSM bool
 
 func init() {
 
@@ -48,6 +49,7 @@ func init() {
 	initConfigGRPCCmd(configCmd)
 	initProtocolCmd(configCmd)
 	initGrahQLCmd(configCmd)
+	initConfigHSMCmd(configCmd)
 
 }
 
@@ -64,6 +66,25 @@ func initConfigCommand() *cobra.Command {
 		}}
 	rootCmd.AddCommand(configCmd)
 	return configCmd
+}
+
+func initConfigHSMCmd(configCmd *cobra.Command) {
+
+	var hsmCmd = &cobra.Command{
+		Use:   "hsm",
+		Short: "HSM configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			config.InitCLIConfiguration(configDir)
+			path, tokenLabel, pin, _ := config.GetHSMConfiguration()
+			config.SetHSMConfiguration(path, tokenLabel, pin, enableHSM)
+			config.WriteConfigFile()
+			cmd.Printf("HSM support set to:%v\n", enableHSM)
+
+		}}
+
+	configCmd.AddCommand(hsmCmd)
+	hsmCmd.Flags().StringVarP(&configDir, "confdir", "", configDir, "Configuration Directory")
+	hsmCmd.Flags().BoolVarP(&enableHSM, "enabled", "e", false, "Enable HSM Support")
 }
 
 func initConfigListCmd(configCmd *cobra.Command) {

--- a/internal/cmd/hsm.go
+++ b/internal/cmd/hsm.go
@@ -27,7 +27,11 @@ func init() {
 	var hsmCmd = &cobra.Command{
 		Use:   "hsm",
 		Short: "HSM commands",
-		Args:  cobra.MinimumNArgs(1),
+		Long: `Utility methods to access the HSM.
+Enable HSM with 
+	edgeca config hsm --enable
+`,
+		Args: cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 
 		}}

--- a/internal/issuer/certificates.go
+++ b/internal/issuer/certificates.go
@@ -166,9 +166,11 @@ func GeneratePemCertificate(subject pkix.Name, possiblyUseHSM bool) (pemCertific
 
 	if config.IsHSMEnaabled() {
 		if possiblyUseHSM {
+			var keyReference string
 			log.Debugf("Signing Certificate for %s using HSM - and storing key in HSM", subject.CommonName)
-			_, pemCertificate, err = GenerateHSMSignedCertificate(certificate, subject.CommonName, subCACert, "EDGECA-SUB-CA")
-			pemPrivateKey = []byte("STORED IN HSM")
+			_, pemCertificate, keyReference, err = GenerateHSMSignedCertificate(certificate, subject.CommonName, subCACert, "EDGECA-SUB-CA")
+
+			pemPrivateKey = []byte(keyReference)
 		} else {
 			log.Debugf("Signing Certificate for %s using HSM - and storing private key in EdgeCA", subject.CommonName)
 			var serverKey *rsa.PrivateKey
@@ -200,7 +202,7 @@ func GenerateSelfSignedRootCACertAndKey() (err error) {
 		log.Debugf("Generating self signed Root CA Certificate using HSM")
 
 		rootCAPrivateKey = nil
-		rootCACert, rootCAPEMCert, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
+		rootCACert, rootCAPEMCert, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
 
 		if err != nil {
 			return err
@@ -227,7 +229,7 @@ func GenerateSelfSignedSubCACertAndKey() (err error) {
 		log.Debugf("Generating self signed Sub CA Certificate using HSM")
 
 		subCAPrivateKey = nil
-		subCACert, subCAPEMCert, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-SUB-CA", rootCACert, "EDGECA-ROOT-CA")
+		subCACert, subCAPEMCert, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-SUB-CA", rootCACert, "EDGECA-ROOT-CA")
 
 		if err != nil {
 			return err

--- a/internal/issuer/x509_test.go
+++ b/internal/issuer/x509_test.go
@@ -45,12 +45,12 @@ func TestCertificates(t *testing.T) {
 
 	unsignedCertificate, _ := generateX509ertificate(root, x509.KeyUsageCertSign|x509.KeyUsageCRLSign, true)
 
-	parentCertificate, _, err := GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
+	parentCertificate, _, _, err := GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
 	if err != nil {
 		t.Fatalf("GetEdgeRootCASigner %v", err)
 	}
 
-	_, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-SUB-CA", parentCertificate, "EDGECA-ROOT-CA")
+	_, _, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-SUB-CA", parentCertificate, "EDGECA-ROOT-CA")
 	if err != nil {
 		t.Fatalf("GetEdgeRootCASigner %v", err)
 	}
@@ -58,7 +58,7 @@ func TestCertificates(t *testing.T) {
 	config.SetHSMConfiguration("", "", "", false)
 	hsm.ResetConfiguration()
 
-	_, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
+	_, _, _, err = GenerateHSMSignedCertificate(unsignedCertificate, "EDGECA-ROOT-CA", nil, "")
 	if err == nil {
 		t.Fatalf("GenerateHSMSignedCertificate should fail when HSM isn't set up")
 	}


### PR DESCRIPTION
When a public/private keypair is created for a new certificate, then
EdgeCA now uses a UUID for the key ID and prints that out, to identify the
key in softHSM